### PR TITLE
Camera: Support obtaining camera memory from MemoryHeapIon

### DIFF
--- a/services/camera/libcameraservice/Android.mk
+++ b/services/camera/libcameraservice/Android.mk
@@ -79,6 +79,10 @@ LOCAL_C_INCLUDES += \
 
 LOCAL_CFLAGS += -Wall -Wextra
 
+ifeq ($(BOARD_NEEDS_MEMORYHEAPION),true)
+    LOCAL_CFLAGS += -DUSE_MEMORY_HEAP_ION
+endif
+
 LOCAL_MODULE:= libcameraservice
 
 include $(BUILD_SHARED_LIBRARY)

--- a/services/camera/libcameraservice/device1/CameraHardwareInterface.h
+++ b/services/camera/libcameraservice/device1/CameraHardwareInterface.h
@@ -26,6 +26,9 @@
 #include <camera/CameraParameters.h>
 #include <system/window.h>
 #include <hardware/camera.h>
+#ifdef USE_MEMORY_HEAP_ION
+#include <binder/MemoryHeapIon.h>
+#endif
 
 namespace android {
 
@@ -501,7 +504,11 @@ private:
                          mBufSize(buf_size),
                          mNumBufs(num_buffers)
         {
+#ifdef USE_MEMORY_HEAP_ION
+            mHeap = new MemoryHeapIon(fd, buf_size * num_buffers);
+#else
             mHeap = new MemoryHeapBase(fd, buf_size * num_buffers);
+#endif
             commonInitialization();
         }
 
@@ -509,7 +516,11 @@ private:
                          mBufSize(buf_size),
                          mNumBufs(num_buffers)
         {
+#ifdef USE_MEMORY_HEAP_ION
+            mHeap = new MemoryHeapIon(buf_size * num_buffers);
+#else
             mHeap = new MemoryHeapBase(buf_size * num_buffers);
+#endif
             commonInitialization();
         }
 
@@ -541,14 +552,24 @@ private:
         camera_memory_t handle;
     };
 
+#ifdef USE_MEMORY_HEAP_ION
+    static camera_memory_t* __get_memory(int fd, size_t buf_size, uint_t num_bufs,
+                                         void *ion_fd)
+    {
+#else
     static camera_memory_t* __get_memory(int fd, size_t buf_size, uint_t num_bufs,
                                          void *user __attribute__((unused)))
     {
+#endif
         CameraHeapMemory *mem;
         if (fd < 0)
             mem = new CameraHeapMemory(buf_size, num_bufs);
         else
             mem = new CameraHeapMemory(fd, buf_size, num_bufs);
+#ifdef USE_MEMORY_HEAP_ION
+        if (ion_fd)
+            *((int *) ion_fd) = mem->mHeap->getHeapID();
+#endif
         mem->incStrong(mem);
         return &mem->handle;
     }


### PR DESCRIPTION
* Exynos 5 devices want the ION file descriptor from MemoryHeapIon

Change-Id: I9e445cf24c15713f713181667e7b7caa1a96592e